### PR TITLE
Add Korora IRC Channel as first channel on Konversation

### DIFF
--- a/build/sources/korora-kdesettings.patch
+++ b/build/sources/korora-kdesettings.patch
@@ -1,6 +1,6 @@
-diff -Nurd kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/applications/mimeapps.list kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/applications/mimeapps.list
---- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/applications/mimeapps.list	2012-05-01 02:57:22.000000000 +1000
-+++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/applications/mimeapps.list	2013-06-10 12:17:54.754600424 +1000
+diff -Naur kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/applications/mimeapps.list kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/applications/mimeapps.list
+--- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/applications/mimeapps.list	2012-04-30 09:57:22.000000000 -0700
++++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/applications/mimeapps.list	2013-09-27 13:49:31.912350028 -0700
 @@ -1,3 +1,16 @@
  [Added Associations]
  application/x-bittorrent=kde4-ktorrent.desktop;kde4-kget.desktop;
@@ -18,43 +18,43 @@ diff -Nurd kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/sh
 +x-content/audio-player=vlc.desktop;kde4-amarok.desktop;
 +x-content/ebook-reader=calibre-gui.desktop;
 +x-content/video-bluray=vlc.desktop;
-diff -Nurd kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/activitymanagerrc kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/activitymanagerrc
---- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/activitymanagerrc	1970-01-01 10:00:00.000000000 +1000
-+++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/activitymanagerrc	2013-06-10 11:51:18.366722281 +1000
+diff -Naur kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/activitymanagerrc kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/activitymanagerrc
+--- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/activitymanagerrc	1969-12-31 17:00:00.000000000 -0700
++++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/activitymanagerrc	2013-09-27 13:49:31.913350028 -0700
 @@ -0,0 +1,5 @@
 +[activities]
 +5a2687b3-214c-47e1-bff4-f73f420153bd=New Activity
 +
 +[main]
 +currentActivity=5a2687b3-214c-47e1-bff4-f73f420153bd
-diff -Nurd kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/default_components kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/default_components
---- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/default_components	1970-01-01 10:00:00.000000000 +1000
-+++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/default_components	2013-06-10 11:51:18.366722281 +1000
+diff -Naur kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/default_components kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/default_components
+--- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/default_components	1969-12-31 17:00:00.000000000 -0700
++++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/default_components	2013-09-27 13:49:31.913350028 -0700
 @@ -0,0 +1,2 @@
 +[InstantMessenger]
 +imClient[$e]=ktp-contactlist
-diff -Nurd kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/dolphinrc kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/dolphinrc
---- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/dolphinrc	1970-01-01 10:00:00.000000000 +1000
-+++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/dolphinrc	2013-06-10 11:51:18.366722281 +1000
+diff -Naur kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/dolphinrc kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/dolphinrc
+--- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/dolphinrc	1969-12-31 17:00:00.000000000 -0700
++++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/dolphinrc	2013-09-27 13:49:31.913350028 -0700
 @@ -0,0 +1,2 @@
 +[PreviewSettings]
 +Plugins=directorythumbnail,djvuthumbnail,fontthumbnail,htmlthumbnail,imagethumbnail,jpegthumbnail,gsthumbnail,rawthumbnail,svgthumbnail,textthumbnail,ffmpegthumbs
-diff -Nurd kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kcmcddbrc kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kcmcddbrc
---- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kcmcddbrc	1970-01-01 10:00:00.000000000 +1000
-+++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kcmcddbrc	2013-06-10 11:51:18.366722281 +1000
+diff -Naur kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kcmcddbrc kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kcmcddbrc
+--- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kcmcddbrc	1969-12-31 17:00:00.000000000 -0700
++++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kcmcddbrc	2013-09-27 13:49:31.914350028 -0700
 @@ -0,0 +1,2 @@
 +[Lookup]
 +MusicBrainzLookupEnabled=true
-diff -Nurd kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kcmfonts kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kcmfonts
---- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kcmfonts	1970-01-01 10:00:00.000000000 +1000
-+++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kcmfonts	2013-06-10 11:51:18.366722281 +1000
+diff -Naur kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kcmfonts kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kcmfonts
+--- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kcmfonts	1969-12-31 17:00:00.000000000 -0700
++++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kcmfonts	2013-09-27 13:49:31.914350028 -0700
 @@ -0,0 +1,3 @@
 +[General]
 +dontChangeAASettings=false
 +forceFontDPI=96
-diff -Nurd kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kdeglobals kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kdeglobals
---- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kdeglobals	2010-09-04 00:30:38.000000000 +1000
-+++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kdeglobals	2013-06-10 12:18:58.889268410 +1000
+diff -Naur kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kdeglobals kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kdeglobals
+--- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kdeglobals	2010-09-03 07:30:38.000000000 -0700
++++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kdeglobals	2013-09-27 13:49:31.914350028 -0700
 @@ -3,6 +3,9 @@
  AutoCheckAccelerators=false
  
@@ -72,18 +72,18 @@ diff -Nurd kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/sh
 +
 +[KDE]
 +SingleClick=false
-diff -Nurd kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kde.notifyrc kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kde.notifyrc
---- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kde.notifyrc	1970-01-01 10:00:00.000000000 +1000
-+++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kde.notifyrc	2013-06-10 11:51:18.366722281 +1000
+diff -Naur kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kde.notifyrc kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kde.notifyrc
+--- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kde.notifyrc	1969-12-31 17:00:00.000000000 -0700
++++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kde.notifyrc	2013-09-27 13:49:31.915350028 -0700
 @@ -0,0 +1,5 @@
 +[Event/exitkde]
 +Action=
 +Execute=
 +KTTS=
 +Logfile=
-diff -Nurd kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kickoffrc kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kickoffrc
---- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kickoffrc	1970-01-01 10:00:00.000000000 +1000
-+++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kickoffrc	2013-06-10 11:51:18.366722281 +1000
+diff -Naur kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kickoffrc kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kickoffrc
+--- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/kickoffrc	1969-12-31 17:00:00.000000000 -0700
++++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/kickoffrc	2013-09-27 13:49:31.915350028 -0700
 @@ -0,0 +1,9 @@
 +[Favorites]
 +FavoriteURLs=/usr/share/applications/kde4/apper.desktop,/usr/share/applications/kde4/systemsettings.desktop,/usr/share/applications/firefox.desktop,/usr/share/applications/kde4/dolphin.desktop,/usr/share/applications/kde4/konsole.desktop
@@ -94,18 +94,50 @@ diff -Nurd kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/sh
 +[KRunner][PlasmaRunnerManager]
 +pluginWhiteList=places,shell,services,bookmarks,recentdocuments,locations
 +
-diff -Nurd kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/ksmserverrc kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/ksmserverrc
---- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/ksmserverrc	2009-01-17 01:25:39.000000000 +1100
-+++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/ksmserverrc	2013-06-10 11:51:18.367722277 +1000
+diff -Naur kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/konversationrc kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/konversationrc
+--- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/konversationrc	2009-09-08 08:16:56.000000000 -0700
++++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/konversationrc	2013-09-27 13:53:08.981236333 -0700
+@@ -1,13 +1,16 @@
+ [Channel 0]
+-Name=#fedora
++Name=#korora
+ 
+ [Channel 1]
+-Name=#fedora-kde
++Name=#fedora
+ 
+ [Channel 2]
+-Name=#kde
++Name=#fedora-kde
+ 
+ [Channel 3]
++Name=#kde
++
++[Channel 4]
+ Name=#konversation
+ 
+ [Server 0]
+@@ -17,7 +20,7 @@
+ 
+ [ServerGroup 0]
+ AutoConnect=false
+-AutoJoinChannels=Channel 0,Channel 1,Channel 2,Channel 3
++AutoJoinChannels=Channel 0,Channel 1,Channel 2,Channel 3,Channel 4
+ EnableNotifications=true
+ Expanded=false
+ Name=Freenode
+diff -Naur kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/ksmserverrc kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/ksmserverrc
+--- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/ksmserverrc	2009-01-16 07:25:39.000000000 -0700
++++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/ksmserverrc	2013-09-27 13:49:31.915350028 -0700
 @@ -1,4 +1,5 @@
  [General]
 +loginMode=restoreSavedSession
  screenCount=1
  
  [LegacySession: saved at previous logout]
-diff -Nurd kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/servicetype_profilerc kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/servicetype_profilerc
---- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/servicetype_profilerc	1970-01-01 10:00:00.000000000 +1000
-+++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/servicetype_profilerc	2013-06-10 11:51:18.367722277 +1000
+diff -Naur kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/servicetype_profilerc kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/servicetype_profilerc
+--- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/servicetype_profilerc	1969-12-31 17:00:00.000000000 -0700
++++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/servicetype_profilerc	2013-09-27 13:49:31.915350028 -0700
 @@ -0,0 +1,6 @@
 +[PhononBackend]
 +Entry0_Preference=2
@@ -113,9 +145,9 @@ diff -Nurd kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/sh
 +Entry1_Preference=1
 +Entry1_Service=phononbackends/gstreamer.desktop
 +NumberOfEntries=2
-diff -Nurd kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/sonnetrc kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/sonnetrc
---- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/sonnetrc	1970-01-01 10:00:00.000000000 +1000
-+++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/sonnetrc	2013-06-10 12:18:27.985428584 +1000
+diff -Naur kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/sonnetrc kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/sonnetrc
+--- kde-settings-19-23-orig/usr/share/kde-settings/kde-profile/default/share/config/sonnetrc	1969-12-31 17:00:00.000000000 -0700
++++ kde-settings-19-23/usr/share/kde-settings/kde-profile/default/share/config/sonnetrc	2013-09-27 13:49:31.916350028 -0700
 @@ -0,0 +1,7 @@
 +[Spelling]
 +backgroundCheckerEnabled=true


### PR DESCRIPTION
Thought it might be nice for support and to cultivate community involvement to have the Korora IRC channel in Konversation
